### PR TITLE
Potential fix for code scanning alert no. 57: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -14,7 +14,7 @@ module.exports = function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : req.params.id
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/tspascoal-ce-dev/ghas-workshop/security/code-scanning/57](https://github.com/tspascoal-ce-dev/ghas-workshop/security/code-scanning/57)

To fix the issue, we need to eliminate the use of the `$where` clause with dynamically interpolated user input. Instead, we should use a parameterized query or a direct query filter that does not involve JavaScript evaluation. This ensures that user input is treated as data rather than executable code.

Specifically:
1. Replace the `$where` clause with a direct query filter using the `orderId` field.
2. Ensure that the `id` parameter is properly sanitized and validated to prevent injection attacks.

The changes will involve:
- Replacing the `$where` clause on line 17 with a direct query filter `{ orderId: id }`.
- Retaining the existing sanitization logic for `id` when `reflectedXssChallenge` is disabled.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
